### PR TITLE
chore: cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 
-import Canvas from "./components/Canvas";
-import FloatingPlayPause from "./components/FloatingPlayPause";
-import FloatingSideBar from "./components/FloatingSidebar";
-import FloatingToolBar from "./components/FloatingToolBar";
+import { Canvas } from "./components/Canvas";
+import { FloatingPlayPause } from "./components/FloatingPlayPause";
+import { FloatingSideBar } from "./components/FloatingSidebar";
+import { FloatingToolBar } from "./components/FloatingToolBar";
 import AppStateContext from "./context/AppStateContext";
 import { getDefaultAppState } from "./context/defaults";
 import { type AppState } from "./context/types";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { Canvas } from "./components/Canvas";
 import { FloatingPlayPause } from "./components/FloatingPlayPause";
 import { FloatingSideBar } from "./components/FloatingSidebar";
 import { FloatingToolBar } from "./components/FloatingToolBar";
-import AppStateContext from "./context/AppStateContext";
+import { AppStateContext } from "./context/AppStateContext";
 import { getDefaultAppState } from "./context/defaults";
 import { type AppState } from "./context/types";
 

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -14,7 +14,7 @@ function mapCoordinates(
   };
 }
 
-export default function Canvas({
+export function Canvas({
   x,
   y,
   color,

--- a/src/components/CanvasItems/Road.tsx
+++ b/src/components/CanvasItems/Road.tsx
@@ -1,9 +1,11 @@
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Image } from "react-konva";
+
+import useAppContext from '~/hooks/useAppState';
 
 import roadImageHorizontal from "~/assets/roadHorizontal.png";
 import roadImageVertical from "~/assets/roadVertical.png";
-import AppStateContext from "~/context/AppStateContext";
+
 import {
   ModalViewNames,
   RoadDirections,
@@ -18,7 +20,7 @@ export interface RoadProps {
 }
 
 export function Road(props: RoadProps) {
-  const { appState, setAppState } = useContext(AppStateContext);
+  const { appState, setAppState } = useAppContext();
 
   const canvasProps: CanvasItemProps = props.canvasProps;
   const roadFields: RoadFields = props.roadFields;

--- a/src/components/CanvasItems/Road.tsx
+++ b/src/components/CanvasItems/Road.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Image } from "react-konva";
 
-import useAppContext from '~/hooks/useAppState';
+import { useAppState } from '~/hooks/useAppState';
 
 import roadImageHorizontal from "~/assets/roadHorizontal.png";
 import roadImageVertical from "~/assets/roadVertical.png";
@@ -20,7 +20,7 @@ export interface RoadProps {
 }
 
 export function Road(props: RoadProps) {
-  const { appState, setAppState } = useAppContext();
+  const { appState, setAppState } = useAppState();
 
   const canvasProps: CanvasItemProps = props.canvasProps;
   const roadFields: RoadFields = props.roadFields;

--- a/src/components/FloatingPlayPause.tsx
+++ b/src/components/FloatingPlayPause.tsx
@@ -1,9 +1,8 @@
-import { useContext } from "react";
+import useAppContext from '~/hooks/useAppState';
 
-import AppStateContext from "~/context/AppStateContext";
 
 export function FloatingPlayPause() {
-  const { appState, setAppState } = useContext(AppStateContext);
+  const { appState, setAppState } = useAppContext();
 
   function playPause() {
     setAppState({

--- a/src/components/FloatingPlayPause.tsx
+++ b/src/components/FloatingPlayPause.tsx
@@ -1,8 +1,8 @@
-import useAppContext from '~/hooks/useAppState';
+import { useAppState } from '~/hooks/useAppState';
 
 
 export function FloatingPlayPause() {
-  const { appState, setAppState } = useAppContext();
+  const { appState, setAppState } = useAppState();
 
   function playPause() {
     setAppState({

--- a/src/components/FloatingPlayPause.tsx
+++ b/src/components/FloatingPlayPause.tsx
@@ -2,7 +2,7 @@ import { useContext } from "react";
 
 import AppStateContext from "~/context/AppStateContext";
 
-export default function FloatingPlayPause() {
+export function FloatingPlayPause() {
   const { appState, setAppState } = useContext(AppStateContext);
 
   function playPause() {

--- a/src/components/FloatingSidebar.tsx
+++ b/src/components/FloatingSidebar.tsx
@@ -3,7 +3,7 @@ import { useContext } from "react";
 import AppStateContext from "~/context/AppStateContext";
 import { closeSidebar, getView, isSideBarOpen } from "~/context/utils/modal";
 
-export default function FloatingSideBar() {
+export function FloatingSideBar() {
   const { appState, setAppState } = useContext(AppStateContext);
 
   return (

--- a/src/components/FloatingSidebar.tsx
+++ b/src/components/FloatingSidebar.tsx
@@ -1,8 +1,8 @@
-import useAppContext from '~/hooks/useAppState';
+import { useAppState } from '~/hooks/useAppState';
 import { closeSidebar, getView, isSideBarOpen } from "~/context/utils/modal";
 
 export function FloatingSideBar() {
-  const { appState, setAppState } = useAppContext();
+  const { appState, setAppState } = useAppState();
 
   return (
     <div

--- a/src/components/FloatingSidebar.tsx
+++ b/src/components/FloatingSidebar.tsx
@@ -1,10 +1,8 @@
-import { useContext } from "react";
-
-import AppStateContext from "~/context/AppStateContext";
+import useAppContext from '~/hooks/useAppState';
 import { closeSidebar, getView, isSideBarOpen } from "~/context/utils/modal";
 
 export function FloatingSideBar() {
-  const { appState, setAppState } = useContext(AppStateContext);
+  const { appState, setAppState } = useAppContext();
 
   return (
     <div

--- a/src/components/FloatingToolBar.tsx
+++ b/src/components/FloatingToolBar.tsx
@@ -1,9 +1,9 @@
-import useAppContext from '~/hooks/useAppState';
+import { useAppState } from '~/hooks/useAppState';
 import { getToolBarItems, isToolBarOpen } from '~/context/utils/modal';
 import { ToolBarItem } from './ToolBar/ToolBarItem';
 
 export function FloatingToolBar() {
-    const { appState } = useAppContext();
+    const { appState } = useAppState();
 
     return (
       <span

--- a/src/components/FloatingToolBar.tsx
+++ b/src/components/FloatingToolBar.tsx
@@ -3,7 +3,7 @@ import AppStateContext from "~/context/AppStateContext";
 import { getToolBarItems, isToolBarOpen } from '~/context/utils/modal';
 import { ToolBarItem } from './ToolBar/ToolBarItem';
 
-export default function FloatingToolBar() {
+export function FloatingToolBar() {
     const { appState } = useContext(AppStateContext);
 
     return (

--- a/src/components/FloatingToolBar.tsx
+++ b/src/components/FloatingToolBar.tsx
@@ -1,10 +1,9 @@
-import { useContext } from 'react';
-import AppStateContext from "~/context/AppStateContext";
+import useAppContext from '~/hooks/useAppState';
 import { getToolBarItems, isToolBarOpen } from '~/context/utils/modal';
 import { ToolBarItem } from './ToolBar/ToolBarItem';
 
 export function FloatingToolBar() {
-    const { appState } = useContext(AppStateContext);
+    const { appState } = useAppContext();
 
     return (
       <span

--- a/src/components/Modals/IntersectionPropertiesEditor.tsx
+++ b/src/components/Modals/IntersectionPropertiesEditor.tsx
@@ -1,3 +1,3 @@
-export default function IntersectionPropertiesEditor() {
+export function IntersectionPropertiesEditor() {
   return <p>NOT YET IMPLEMENTED</p>;
 }

--- a/src/components/Modals/RoadPropertiesEditor.tsx
+++ b/src/components/Modals/RoadPropertiesEditor.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { RoadDirections, type Road } from "~/context/types";
 import { ColumnStack, RowStack } from "~/components/Stacks";
 
-import useAppContext from '~/hooks/useAppState';
+import { useAppState } from '~/hooks/useAppState';
 
 interface RoadPropertiesEditorProps {
   speedLimit?: number;
@@ -16,7 +16,7 @@ export function RoadPropertiesEditor(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _props: RoadPropertiesEditorProps
 ) {
-  const { appState, setAppState } = useAppContext();
+  const { appState, setAppState } = useAppState();
 
   const [newSpeedLimit, setNewSpeedLimit] = useState(0);
   const [newLanes, setNewLanes] = useState(0);

--- a/src/components/Modals/RoadPropertiesEditor.tsx
+++ b/src/components/Modals/RoadPropertiesEditor.tsx
@@ -11,7 +11,7 @@ interface RoadPropertiesEditorProps {
 }
 
 // TODO: check if we need the props parameter
-export default function RoadPropertiesEditor(
+export function RoadPropertiesEditor(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _props: RoadPropertiesEditorProps
 ) {

--- a/src/components/Modals/RoadPropertiesEditor.tsx
+++ b/src/components/Modals/RoadPropertiesEditor.tsx
@@ -1,8 +1,9 @@
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
-import AppStateContext from "~/context/AppStateContext";
 import { RoadDirections, type Road } from "~/context/types";
 import { ColumnStack, RowStack } from "~/components/Stacks";
+
+import useAppContext from '~/hooks/useAppState';
 
 interface RoadPropertiesEditorProps {
   speedLimit?: number;
@@ -15,7 +16,7 @@ export function RoadPropertiesEditor(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _props: RoadPropertiesEditorProps
 ) {
-  const { appState, setAppState } = useContext(AppStateContext);
+  const { appState, setAppState } = useAppContext();
 
   const [newSpeedLimit, setNewSpeedLimit] = useState(0);
   const [newLanes, setNewLanes] = useState(0);

--- a/src/components/Road.tsx
+++ b/src/components/Road.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-function Road() {
+export function Road() {
   const [speedLimit, setSpeedLimit] = useState("");
   const [numLanes, setNumLanes] = useState("");
   const [direction, setDirection] = useState("north");
@@ -80,5 +80,3 @@ function Road() {
     </div>
   );
 }
-
-export default Road;

--- a/src/context/AppStateContext.ts
+++ b/src/context/AppStateContext.ts
@@ -3,7 +3,7 @@ import { createContext, type Dispatch, type SetStateAction } from "react";
 import { getDefaultAppState } from "./defaults";
 import { type AppState } from "./types";
 
-type AppStateContextType = {
+export type AppStateContextType = {
   appState: AppState;
   setAppState: Dispatch<SetStateAction<AppState>>;
 };
@@ -15,7 +15,5 @@ const AppStateContextState = {
   },
 };
 
-const AppStateContext =
+export const AppStateContext =
   createContext<AppStateContextType>(AppStateContextState);
-
-export default AppStateContext;

--- a/src/context/utils/modal.tsx
+++ b/src/context/utils/modal.tsx
@@ -1,7 +1,7 @@
 import { type Dispatch, type SetStateAction } from "react";
 
-import IntersectionPropertiesEditor from "~/components/Modals/IntersectionPropertiesEditor";
-import RoadPropertiesEditor from "~/components/Modals/RoadPropertiesEditor";
+import { IntersectionPropertiesEditor } from "~/components/Modals/IntersectionPropertiesEditor";
+import { RoadPropertiesEditor } from "~/components/Modals/RoadPropertiesEditor";
 import { ModalViewNames, type AppState, type CanvasItemTypes } from "~/context/types";
 
 export function openSidebar(

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { AppStateContext, AppStateContextType } from "~/context/AppStateContext";
+
+export default function useAppContext(): AppStateContextType {
+  return useContext(AppStateContext);
+}

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { AppStateContext, AppStateContextType } from "~/context/AppStateContext";
 
-export default function useAppState(): AppStateContextType {
+export function useAppState(): AppStateContextType {
   return useContext(AppStateContext);
 }

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { AppStateContext, AppStateContextType } from "~/context/AppStateContext";
 
-export default function useAppContext(): AppStateContextType {
+export default function useAppState(): AppStateContextType {
   return useContext(AppStateContext);
 }


### PR DESCRIPTION
* removes most of the default exports
* adds `useAppState` hook instead of import `useContext` and the `AppStateContext` every time we want to use it