### PR TITLE
Fix edge to node click

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -159,7 +159,7 @@ export function Canvas() {
                     );
                     selector.deselect();
                   } else {
-                    selector.deselect();
+                    selector.select(node.id);
                   }
                 }}
               />

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -149,11 +149,16 @@ export function Canvas() {
                     selector.deselect();
                   }
                   // if another node is selected, then draw an edge
-                  else if (selector.selected !== node.id) {
+                  else if (
+                    selector.selected !== node.id &&
+                    network.nodes[selector.selected]
+                  ) {
                     network.drawEdge(
                       network.nodes[selector.selected],
                       network.nodes[node.id],
                     );
+                    selector.deselect();
+                  } else {
                     selector.deselect();
                   }
                 }}


### PR DESCRIPTION
Right now when a user has selected an edge then clicks on a node it tries to draw an edge between them

So, this code change just selects the node that is clicked when the selected item is not a node aka edge