### PR TITLE
feat: undo redo stack

### DIFF
--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -6,6 +6,10 @@
 
 - [Zustand](https://docs.pmnd.rs/zustand/getting-started/introduction)
 
+### Undo/Redo
+
+- [Command pattern](https://en.wikipedia.org/wiki/Command_pattern)
+
 ### SUMO - (Simulation of Urban MObility)
 
 [SUMO user documentation](https://sumo.dlr.de/docs/index.html)

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -15,6 +15,7 @@ import {
   useStageState,
 } from '~/zustand/useStage';
 import { useToolbarStore } from '~/zustand/useToolbar';
+import { useUndoStore } from '~/zustand/useUndoStore';
 
 import { CarLayer } from './Layers/CarLayer';
 import { ConnectionsLayer } from './Layers/ConnectionsLayer';
@@ -26,6 +27,7 @@ export function Canvas() {
   const network = useNetworkStore();
   const nodes = Object.values(network.nodes);
   const toolbarState = useToolbarStore();
+  const undoStore = useUndoStore();
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -43,6 +45,18 @@ export function Canvas() {
         } else {
           throw new Error("cannot delete selected because it doesn't exist");
         }
+      }
+
+      const isUndoCommand =
+        (e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === 'z';
+      const isRedoCommand =
+        (e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'z';
+
+      if (isUndoCommand) {
+        undoStore.undo();
+      }
+      if (isRedoCommand) {
+        undoStore.redo();
       }
 
       if (isEsc && selector.selected) {

--- a/src/components/ProjectUploadButton.tsx
+++ b/src/components/ProjectUploadButton.tsx
@@ -3,10 +3,12 @@ import { ArrowUpTrayIcon } from '@heroicons/react/20/solid';
 import { getNetworkFromUploadedFile } from '~/logic/urbanflo-file-logic';
 import { useNetworkStore } from '~/zustand/useNetworkStore';
 import { useSimulationHistory } from '~/zustand/useSimulationHistory';
+import { useUndoStore } from '~/zustand/useUndoStore';
 
 export function ProjectUploadButton() {
   const networkStore = useNetworkStore();
   const simulationHistoryStore = useSimulationHistory();
+  const undoStore = useUndoStore();
 
   function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
@@ -40,6 +42,10 @@ export function ProjectUploadButton() {
               simulationHistoryStore.updateHistory(historyItem);
             },
           );
+
+          // Since the deleteNode, addNode, and drawEdge methods add to the undo stack,
+          // we want to clear after building the network.
+          undoStore.clearStacks();
         } catch (error) {
           console.error(
             'An error occurred while parsing the JSON file OR the file is invalid',

--- a/src/helpers/commands/AddEdgeCommand.ts
+++ b/src/helpers/commands/AddEdgeCommand.ts
@@ -1,0 +1,27 @@
+import { Edge } from '~/types/Network';
+import { Network } from '~/zustand/useNetworkStore';
+import { Command } from '~/zustand/useUndoStore';
+
+export class AddEdgeCommand extends Command {
+  constructor(
+    private network: Network,
+    private edge: Edge,
+  ) {
+    super();
+  }
+
+  execute() {
+    const fromNode = this.network.nodes[this.edge.from];
+    const toNode = this.network.nodes[this.edge.to];
+
+    if (!fromNode && !toNode) {
+      return;
+    }
+
+    this.network.drawEdge(fromNode, toNode);
+  }
+
+  unexecute() {
+    this.network.deleteEdge(this.edge.id);
+  }
+}

--- a/src/helpers/commands/AddEdgeCommand.ts
+++ b/src/helpers/commands/AddEdgeCommand.ts
@@ -2,13 +2,11 @@ import { Edge } from '~/types/Network';
 import { Network } from '~/zustand/useNetworkStore';
 import { Command } from '~/zustand/useUndoStore';
 
-export class AddEdgeCommand extends Command {
+export class AddEdgeCommand implements Command {
   constructor(
     private network: Network,
     private edge: Edge,
-  ) {
-    super();
-  }
+  ) {}
 
   execute() {
     const fromNode = this.network.nodes[this.edge.from];

--- a/src/helpers/commands/AddNodeCommand.ts
+++ b/src/helpers/commands/AddNodeCommand.ts
@@ -1,0 +1,20 @@
+import { Node } from '~/types/Network';
+import { Network } from '~/zustand/useNetworkStore';
+import { Command } from '~/zustand/useUndoStore';
+
+export class AddNodeCommand extends Command {
+  constructor(
+    private network: Network,
+    private node: Node,
+  ) {
+    super();
+  }
+
+  execute() {
+    this.network.addNode(this.node);
+  }
+
+  unexecute() {
+    this.network.deleteNode(this.node.id);
+  }
+}

--- a/src/helpers/commands/AddNodeCommand.ts
+++ b/src/helpers/commands/AddNodeCommand.ts
@@ -2,13 +2,11 @@ import { Node } from '~/types/Network';
 import { Network } from '~/zustand/useNetworkStore';
 import { Command } from '~/zustand/useUndoStore';
 
-export class AddNodeCommand extends Command {
+export class AddNodeCommand implements Command {
   constructor(
     private network: Network,
     private node: Node,
-  ) {
-    super();
-  }
+  ) {}
 
   execute() {
     this.network.addNode(this.node);

--- a/src/helpers/commands/RemoveEdgeCommand.ts
+++ b/src/helpers/commands/RemoveEdgeCommand.ts
@@ -2,13 +2,11 @@ import { Edge } from '~/types/Network';
 import { Network } from '~/zustand/useNetworkStore';
 import { Command } from '~/zustand/useUndoStore';
 
-export class RemoveEdgeCommand extends Command {
+export class RemoveEdgeCommand implements Command {
   constructor(
     private network: Network,
     private edge: Edge,
-  ) {
-    super();
-  }
+  ) {}
 
   execute() {
     this.network.deleteEdge(this.edge.id);

--- a/src/helpers/commands/RemoveEdgeCommand.ts
+++ b/src/helpers/commands/RemoveEdgeCommand.ts
@@ -1,0 +1,27 @@
+import { Edge } from '~/types/Network';
+import { Network } from '~/zustand/useNetworkStore';
+import { Command } from '~/zustand/useUndoStore';
+
+export class RemoveEdgeCommand extends Command {
+  constructor(
+    private network: Network,
+    private edge: Edge,
+  ) {
+    super();
+  }
+
+  execute() {
+    this.network.deleteEdge(this.edge.id);
+  }
+
+  unexecute() {
+    const fromNode = this.network.nodes[this.edge.from];
+    const toNode = this.network.nodes[this.edge.to];
+
+    if (!fromNode && !toNode) {
+      return;
+    }
+
+    this.network.drawEdge(fromNode, toNode);
+  }
+}

--- a/src/helpers/commands/RemoveNodeCommand.ts
+++ b/src/helpers/commands/RemoveNodeCommand.ts
@@ -2,13 +2,11 @@ import { Node } from '~/types/Network';
 import { Network } from '~/zustand/useNetworkStore';
 import { Command } from '~/zustand/useUndoStore';
 
-export class RemoveNodeCommand extends Command {
+export class RemoveNodeCommand implements Command {
   constructor(
     private network: Network,
     private node: Node,
-  ) {
-    super();
-  }
+  ) {}
 
   execute() {
     this.network.deleteNode(this.node.id);

--- a/src/helpers/commands/RemoveNodeCommand.ts
+++ b/src/helpers/commands/RemoveNodeCommand.ts
@@ -1,0 +1,20 @@
+import { Node } from '~/types/Network';
+import { Network } from '~/zustand/useNetworkStore';
+import { Command } from '~/zustand/useUndoStore';
+
+export class RemoveNodeCommand extends Command {
+  constructor(
+    private network: Network,
+    private node: Node,
+  ) {
+    super();
+  }
+
+  execute() {
+    this.network.deleteNode(this.node.id);
+  }
+
+  unexecute() {
+    this.network.addNode(this.node);
+  }
+}

--- a/src/zustand/useNetworkStore.ts
+++ b/src/zustand/useNetworkStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 
 import { laneWidth } from '~/components/Canvas/Road';
+import { AddNodeCommand } from '~/helpers/commands/AddNodeCommand';
+import { RemoveNodeCommand } from '~/helpers/commands/RemoveNodeCommand';
 import {
   edgeDoesIntersect,
   removeItems,
@@ -8,6 +10,8 @@ import {
   updateConnectionsOnLaneChange,
 } from '~/helpers/zustand/NetworkStoreHelpers';
 import { Connection, Edge, Flow, Node, Route, VType } from '~/types/Network';
+
+import { useUndoStore } from './useUndoStore';
 
 export interface NetworkData {
   documentName: string;
@@ -31,7 +35,7 @@ export interface Network extends NetworkData {
   updateFlow: (flowId: string, flow: Flow) => void;
 }
 
-export const useNetworkStore = create<Network>(set => ({
+export const useNetworkStore = create<Network>((set, get) => ({
   documentName: 'Untitled Document',
   nodes: {},
   edges: {},
@@ -43,8 +47,11 @@ export const useNetworkStore = create<Network>(set => ({
   setDocumentName: name => {
     set({ documentName: name });
   },
-  addNode: (node: Node) =>
-    set(state => ({ nodes: { ...state.nodes, [node.id]: node } })),
+  addNode: (node: Node) => {
+    const undoStore = useUndoStore.getState();
+    undoStore.pushCommand(new AddNodeCommand(get(), node));
+    set(state => ({ nodes: { ...state.nodes, [node.id]: node } }));
+  },
   updateNode: (nodeId, node) => {
     set(state => {
       return {
@@ -194,6 +201,8 @@ export const useNetworkStore = create<Network>(set => ({
     });
   },
   deleteNode: (id: string) => {
+    const undoStore = useUndoStore.getState();
+    undoStore.pushCommand(new RemoveNodeCommand(get(), get().nodes[id]));
     set(state => {
       const newNodes = { ...state.nodes };
       delete newNodes[id];

--- a/src/zustand/useUndoStore.ts
+++ b/src/zustand/useUndoStore.ts
@@ -43,6 +43,7 @@ export const useUndoStore = create<UndoRedoStore>((set, get) => ({
       return;
     }
 
+    lastCommand.execute();
 
     set({
       redoStack: [...redoStack],

--- a/src/zustand/useUndoStore.ts
+++ b/src/zustand/useUndoStore.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand';
 
-export abstract class Command {
-  abstract execute(): void;
-  abstract unexecute(): void;
+export interface Command {
+  execute(): void;
+  unexecute(): void;
 }
 
 interface UndoRedoStore {

--- a/src/zustand/useUndoStore.ts
+++ b/src/zustand/useUndoStore.ts
@@ -29,7 +29,11 @@ export const useUndoStore = create<UndoRedoStore>((set, get) => ({
     }
 
     lastCommand.unexecute();
-    redoStack.push(lastCommand);
+
+    set({
+      redoStack: [...redoStack, lastCommand],
+      undoStack: [...undoStack],
+    });
   },
   redo: () => {
     const { undoStack, redoStack } = get();
@@ -39,8 +43,11 @@ export const useUndoStore = create<UndoRedoStore>((set, get) => ({
       return;
     }
 
-    lastCommand.unexecute();
-    undoStack.push(lastCommand);
+
+    set({
+      redoStack: [...redoStack],
+      undoStack: [...undoStack, lastCommand],
+    });
   },
   clearStacks: () => set({ undoStack: [], redoStack: [] }),
   setStacks: (undoStack, redoStack) => set({ undoStack, redoStack }),

--- a/src/zustand/useUndoStore.ts
+++ b/src/zustand/useUndoStore.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand';
+
+export abstract class Command {
+  abstract execute(): void;
+  abstract unexecute(): void;
+}
+
+interface UndoRedoStore {
+  undoStack: Command[];
+  redoStack: Command[];
+  pushCommand: (command: Command) => void;
+  undo: () => void;
+  redo: () => void;
+  clearStacks: () => void;
+  setStacks: (undoStack: Command[], redoStack: Command[]) => void;
+}
+
+export const useUndoStore = create<UndoRedoStore>((set, get) => ({
+  undoStack: [],
+  redoStack: [],
+  pushCommand: command =>
+    set(state => ({ undoStack: [...state.undoStack, command] })),
+  undo: () => {
+    const { undoStack, redoStack } = get();
+    const lastCommand = undoStack.pop();
+
+    if (!lastCommand) {
+      return;
+    }
+
+    lastCommand.unexecute();
+    redoStack.push(lastCommand);
+  },
+  redo: () => {
+    const { undoStack, redoStack } = get();
+    const lastCommand = redoStack.pop();
+
+    if (!lastCommand) {
+      return;
+    }
+
+    lastCommand.unexecute();
+    undoStack.push(lastCommand);
+  },
+  clearStacks: () => set({ undoStack: [], redoStack: [] }),
+  setStacks: (undoStack, redoStack) => set({ undoStack, redoStack }),
+}));


### PR DESCRIPTION
- Adds `useUndoStore`
- Adds commands for adding edge/node and removing edge/node
- Clears stacks after the network is built on upload
- Updates `RESOURCES.md`