### PR TITLE
Always use documentName field in network JSON for document name

### DIFF
--- a/src/components/ProjectUploadButton.tsx
+++ b/src/components/ProjectUploadButton.tsx
@@ -13,12 +13,14 @@ export function ProjectUploadButton() {
   function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
     if (file && file.type === 'application/json') {
-      networkStore.setDocumentName(file.name);
       const reader = new FileReader();
       reader.onload = (e: ProgressEvent<FileReader>) => {
         try {
           const parsedJson = JSON.parse(e.target?.result as string);
           const uploadedNetwork = getNetworkFromUploadedFile(parsedJson);
+
+          // Set document name
+          networkStore.setDocumentName(uploadedNetwork.networkData.documentName);
 
           // Clear the current canvas
           const nodeIds = Object.keys(networkStore.nodes);


### PR DESCRIPTION
Under some situations, the downloaded network file name might be different to `documentName` to avoid clashes with filesystem filename schema, such as `Document 1/2` being downloaded to `Document 1_2.json`.

This PR always use the `documentName` field when uploading the network instead of the file name.