### PR TITLE
Improve keybinds for saving and deleting nodes

### DIFF
--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -36,7 +36,7 @@ export function Canvas() {
   // Keyboard shortcuts
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      const isCommandDelete = (e.metaKey || e.ctrlKey) && e.key === 'Backspace';
+      const isCommandDelete = (e.metaKey && e.key === 'Backspace') || e.key === 'Delete';
       const isEsc = e.key === 'Escape';
 
       if (isCommandDelete && selector.selected) {

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -4,6 +4,8 @@ import { Stage } from 'react-konva';
 import { KonvaEventObject } from 'konva/lib/Node';
 
 import { toolbarItemToDecoration } from '~/helpers/decorationTypes';
+import { handleDownloadEvent } from '~/helpers/zustand/NetworkStoreHelpers.ts';
+import useJsonDownloader from '~/hooks/useJsonDownloader.ts';
 import { createId } from '~/id';
 import { NodeType } from '~/types/Network';
 import { LabelNames } from '~/types/Toolbar';
@@ -23,8 +25,6 @@ import { CarLayer } from './Layers/CarLayer';
 import { DecorationsLayer } from './Layers/DecorationsLayer';
 import { IntersectionsLayer } from './Layers/IntersectionsLayer';
 import { RoadsLayer } from './Layers/RoadsLayer';
-import useJsonDownloader from "~/hooks/useJsonDownloader.ts";
-import { handleDownloadEvent } from "~/helpers/zustand/NetworkStoreHelpers.ts";
 
 export function Canvas() {
   const selector = useSelector();
@@ -38,7 +38,8 @@ export function Canvas() {
   // Keyboard shortcuts
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      const isCommandDelete = (e.metaKey && e.key === 'Backspace') || e.key === 'Delete';
+      const isCommandDelete =
+        (e.metaKey && e.key === 'Backspace') || e.key === 'Delete';
       const isEsc = e.key === 'Escape';
       const isSave = (e.metaKey || e.ctrlKey) && e.key === 's';
 

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -20,10 +20,11 @@ import { useToolbarStore } from '~/zustand/useToolbar';
 import { useUndoStore } from '~/zustand/useUndoStore';
 
 import { CarLayer } from './Layers/CarLayer';
-import { ConnectionsLayer } from './Layers/ConnectionsLayer';
 import { DecorationsLayer } from './Layers/DecorationsLayer';
 import { IntersectionsLayer } from './Layers/IntersectionsLayer';
 import { RoadsLayer } from './Layers/RoadsLayer';
+import useJsonDownloader from "~/hooks/useJsonDownloader.ts";
+import { handleDownloadEvent } from "~/helpers/zustand/NetworkStoreHelpers.ts";
 
 export function Canvas() {
   const selector = useSelector();
@@ -32,12 +33,19 @@ export function Canvas() {
   const toolbarState = useToolbarStore();
   const undoStore = useUndoStore();
   const decorationsStore = useDecorationStore();
+  const downloadJson = useJsonDownloader();
 
   // Keyboard shortcuts
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       const isCommandDelete = (e.metaKey && e.key === 'Backspace') || e.key === 'Delete';
       const isEsc = e.key === 'Escape';
+      const isSave = (e.metaKey || e.ctrlKey) && e.key === 's';
+
+      if (isSave) {
+        e.preventDefault(); // override browser's save page dialog
+        handleDownloadEvent(downloadJson, network);
+      }
 
       if (isCommandDelete && selector.selected) {
         if (network.nodes[selector.selected]) {

--- a/src/components/ProjectDownloadButton.tsx
+++ b/src/components/ProjectDownloadButton.tsx
@@ -1,8 +1,8 @@
 import { ArrowDownTrayIcon } from '@heroicons/react/20/solid';
 
+import { handleDownloadEvent } from '~/helpers/zustand/NetworkStoreHelpers.ts';
 import useJsonDownloader from '~/hooks/useJsonDownloader';
 import { useNetworkStore } from '~/zustand/useNetworkStore';
-import { handleDownloadEvent } from "~/helpers/zustand/NetworkStoreHelpers.ts";
 
 export function ProjectDownloadButton() {
   const downloadJson = useJsonDownloader();

--- a/src/components/ProjectDownloadButton.tsx
+++ b/src/components/ProjectDownloadButton.tsx
@@ -1,15 +1,14 @@
 import { ArrowDownTrayIcon } from '@heroicons/react/20/solid';
 
 import useJsonDownloader from '~/hooks/useJsonDownloader';
-import { getUrbanFloFileContents } from '~/logic/urbanflo-file-logic';
 import { useNetworkStore } from '~/zustand/useNetworkStore';
+import { handleDownloadEvent } from "~/helpers/zustand/NetworkStoreHelpers.ts";
 
 export function ProjectDownloadButton() {
   const downloadJson = useJsonDownloader();
   const network = useNetworkStore();
   function handleDownloadClick() {
-    const jsonString = getUrbanFloFileContents();
-    downloadJson(jsonString, network.documentName);
+    handleDownloadEvent(downloadJson, network);
   }
 
   return (

--- a/src/helpers/zustand/NetworkStoreHelpers.ts
+++ b/src/helpers/zustand/NetworkStoreHelpers.ts
@@ -1,7 +1,7 @@
 import { laneWidth } from '~/components/Canvas/Constants/Road';
+import { getUrbanFloFileContents } from '~/logic/urbanflo-file-logic.ts';
 import { Connection, Edge, Flow, Point, Route } from '~/types/Network';
 import { Network, useNetworkStore } from '~/zustand/useNetworkStore';
-import {getUrbanFloFileContents} from "~/logic/urbanflo-file-logic.ts";
 
 /**
  * Given pointA and pointB and a line drawn between edges from C to D
@@ -309,7 +309,10 @@ export function getEdgeTerminals(
   };
 }
 
-export function handleDownloadEvent(downloadJson: (jsonString: string, fileName: string) => void, network: Network) {
+export function handleDownloadEvent(
+  downloadJson: (jsonString: string, fileName: string) => void,
+  network: Network,
+) {
   const jsonString = getUrbanFloFileContents();
   downloadJson(jsonString, network.documentName);
 }

--- a/src/helpers/zustand/NetworkStoreHelpers.ts
+++ b/src/helpers/zustand/NetworkStoreHelpers.ts
@@ -1,6 +1,7 @@
 import { laneWidth } from '~/components/Canvas/Constants/Road';
 import { Connection, Edge, Flow, Point, Route } from '~/types/Network';
 import { Network, useNetworkStore } from '~/zustand/useNetworkStore';
+import {getUrbanFloFileContents} from "~/logic/urbanflo-file-logic.ts";
 
 /**
  * Given pointA and pointB and a line drawn between edges from C to D
@@ -306,4 +307,9 @@ export function getEdgeTerminals(
     leading,
     trailing,
   };
+}
+
+export function handleDownloadEvent(downloadJson: (jsonString: string, fileName: string) => void, network: Network) {
+  const jsonString = getUrbanFloFileContents();
+  downloadJson(jsonString, network.documentName);
 }


### PR DESCRIPTION
- Add <kbd>Del</kbd> key to delete nodes and remove <kbd>Ctrl</kbd> + <kbd>Backspace</kbd> since it's not really a common combination for 'delete something' in the PC world
- Add <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>S</kbd> to save network