### PR TITLE
Format date/time in user's local time zone

### DIFF
--- a/src/helpers/format/format.test.ts
+++ b/src/helpers/format/format.test.ts
@@ -7,8 +7,11 @@ import {
 } from '.';
 
 describe('formatISOString', () => {
+  const utc = 'Etc/UTC';
+  const melbourne = 'Australia/Melbourne';
+
   it('should correctly format ISO string to date and time', () => {
-    const result = formatISOString('2021-09-25T14:15:22.000Z');
+    const result = formatISOString('2021-09-25T14:15:22.000Z', utc);
     expect(result).toEqual({
       date: '25/09/21',
       time: '2:15 PM',
@@ -16,7 +19,7 @@ describe('formatISOString', () => {
   });
 
   it('should correctly handle dates with single-digit day and month', () => {
-    const result = formatISOString('2021-09-05T04:05:22.000Z');
+    const result = formatISOString('2021-09-05T04:05:22.000Z', utc);
     expect(result).toEqual({
       date: '05/09/21',
       time: '4:05 AM',
@@ -25,20 +28,28 @@ describe('formatISOString', () => {
 
   it('should throw an error for invalid date strings', () => {
     expect(() => {
-      formatISOString('invalid-date');
+      formatISOString('invalid-date', utc);
     }).toThrow();
   });
 
   it('should return the correct time in 12-hour format', () => {
-    const result = formatISOString('2021-09-25T14:05:22.000Z');
+    const result = formatISOString('2021-09-25T14:05:22.000Z', utc);
     expect(result.time).toBe('2:05 PM');
   });
 
   it('should correctly handle leap years', () => {
-    const result = formatISOString('2020-02-29T14:05:22.000Z');
+    const result = formatISOString('2020-02-29T14:05:22.000Z', utc);
     expect(result).toEqual({
       date: '29/02/20',
       time: '2:05 PM',
+    });
+  });
+
+  it('should correctly handle daylight saving time', () => {
+    const result = formatISOString('2023-10-01T04:00:00.000Z', melbourne);
+    expect(result).toEqual({
+      date: '01/10/23',
+      time: '3:00 PM',
     });
   });
 });

--- a/src/helpers/format/index.ts
+++ b/src/helpers/format/index.ts
@@ -3,17 +3,17 @@ import { format as formatTz, utcToZonedTime } from 'date-fns-tz';
 
 import { IntersectionType } from '~/types/Network';
 
-export function formatISOString(dateString: string) {
+export function formatISOString(dateString: string, timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone) {
   const date = parseISO(dateString);
 
   if (!isValid(date)) {
     throw new Error('Invalid date string');
   }
 
-  const utcDate = utcToZonedTime(date, 'Etc/UTC');
+  const localDate = utcToZonedTime(date, timeZone);
 
-  const formattedDate = formatTz(utcDate, 'dd/MM/yy', { timeZone: 'Etc/UTC' });
-  const formattedTime = formatTz(utcDate, 'h:mm aa', { timeZone: 'Etc/UTC' });
+  const formattedDate = formatTz(localDate, 'dd/MM/yy', { timeZone: timeZone });
+  const formattedTime = formatTz(localDate, 'h:mm aa', { timeZone: timeZone });
 
   return {
     date: formattedDate,


### PR DESCRIPTION
Add an optional `timeZone` parameter to `formatISOString()`, defaults to user's local time zone